### PR TITLE
Recursively unpack nested structured dtype descrs

### DIFF
--- a/msgpack_numpy.py
+++ b/msgpack_numpy.py
@@ -88,17 +88,29 @@ def decode(obj, chain=None):
                 else:
                     descr = obj[b'type']
                 return np.frombuffer(obj[b'data'],
-                            dtype=np.dtype(descr)).reshape(obj[b'shape'])
+                            dtype=_unpack_dtype(descr)).reshape(obj[b'shape'])
             else:
                 descr = obj[b'type']
                 return np.frombuffer(obj[b'data'],
-                            dtype=np.dtype(descr))[0]
+                            dtype=_unpack_dtype(descr))[0]
         elif b'complex' in obj:
             return complex(tostr(obj[b'data']))
         else:
             return obj if chain is None else chain(obj)
     except KeyError:
         return obj if chain is None else chain(obj)
+
+def _unpack_dtype(dtype):
+    """
+    Unpack dtype descr, recursively unpacking nested structured dtypes.
+    """
+
+    if isinstance(dtype, (list, tuple)):
+        dtype = [
+            (name, _unpack_dtype(subdtype)) + tuple(rest)
+            for name, subdtype, *rest in dtype
+        ]
+    return np.dtype(dtype)
 
 if msgpack.version < (1, 0, 0):
     warnings.warn('support for msgpack < 1.0.0 will be removed in a future release',

--- a/tests.py
+++ b/tests.py
@@ -243,5 +243,44 @@ class test_numpy_msgpack(TestCase):
         x_rec = self.encode_decode_thirdparty(x)
         self.assertEqual(x, x_rec)
 
+    def test_numpy_structured_array(self):
+        structured_dtype = np.dtype([("a", float), ("b", int)])
+
+        x = np.empty((10,), dtype=structured_dtype)
+        x["a"] = np.arange(10)
+        x["b"] = np.arange(10)
+
+        x_rec = self.encode_decode(x)
+
+        assert_array_equal(x, x_rec)
+        self.assertEqual(x.dtype, x_rec.dtype)
+
+    def test_numpy_shaped_structured_array(self):
+        shaped_structured_dtype = np.dtype([("a", float, 3), ("b", int)])
+
+        x = np.empty((10,), dtype=shaped_structured_dtype)
+        x["a"] = np.arange(30).reshape(10, 3)
+        x["b"] = np.arange(10)
+
+        x_rec = self.encode_decode(x)
+
+        assert_array_equal(x, x_rec)
+        self.assertEqual(x.dtype, x_rec.dtype)
+
+    def test_numpy_nested_structured_array(self):
+        structured_dtype = np.dtype([("a", float), ("b", int)])
+        nested_dtype = np.dtype([("foo", structured_dtype), ("bar", structured_dtype)])
+
+        x = np.empty((10,), dtype=nested_dtype)
+        x["foo"]["a"] = np.arange(10)
+        x["foo"]["b"] = np.arange(10)
+        x["bar"]["a"] = np.arange(10) + 10
+        x["bar"]["b"] = np.arange(10) + 10
+
+        x_rec = self.encode_decode(x)
+
+        assert_array_equal(x, x_rec)
+        self.assertEqual(x.dtype, x_rec.dtype)
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #42 

Recursively unpacked nested structured dtypes, as numpy does not properly reinitialize these dtypes directly from `descr`.