### PR TITLE
Fix python 2.7, add support for cross-version tests via tox.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ os:
 
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 
-script:
-    - python tests.py
+install: pip install tox-travis
+script: tox

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Development
 -----------
 The latest source code can be obtained from [GitHub](https://github.com/lebedov/msgpack-numpy/).
 
+msgpack-numpy maintains compatibility with python versions 2.7 and 3.5+.
+
+Install [`tox`](https://tox.readthedocs.io/en/latest/) to support testing
+across multiple python versions in your development environment. If you
+use [`conda`](https://docs.conda.io/en/latest/) to install `python` use
+[`tox-conda`](https://github.com/tox-dev/tox-conda) to automatically manage
+testing across all supported python versions.
+    
+    # Using a system python
+    pip install tox
+
+    # Additionally, using a conda-provided python
+    pip install tox tox-conda
+
+Execute tests across supported python versions:
+    
+    tox
+
 Authors
 -------
 See the included [AUTHORS.md](https://github.com/lebedov/msgpack-numpy/blob/master/AUTHORS.md) file for 

--- a/msgpack_numpy.py
+++ b/msgpack_numpy.py
@@ -106,9 +106,10 @@ def _unpack_dtype(dtype):
     """
 
     if isinstance(dtype, (list, tuple)):
+        # Unpack structured dtypes of the form: (name, type, *shape)
         dtype = [
-            (name, _unpack_dtype(subdtype)) + tuple(rest)
-            for name, subdtype, *rest in dtype
+            (subdtype[0], _unpack_dtype(subdtype[1])) + tuple(subdtype[2:])
+            for subdtype in dtype
         ]
     return np.dtype(dtype)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py{27,35,36,37,38}
+recreate = True
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements.txt
+commands = python tests.py


### PR DESCRIPTION
Fixes #43 #42 

Fix python 2.7 support in dtype unpacking

Add tox configuration for multi version testing, notably cross 2.7/3+.

Add development environment documentation to README.md, specifying use
of `tox` and `tox-conda` for multi-version testing.

Update `travis.yml` to use `tox-travis` integration.

Remove python 3.4 from default test configuration, as version is no
longer available on many platforms and challenging to test locally. Add
python 3.8 to tox and travis test configuration.

Add .gitignore for build/test products.

