### PR TITLE
replace `np.frombuffer` by `np.ndarray` to support object arrays

### DIFF
--- a/msgpack_numpy.py
+++ b/msgpack_numpy.py
@@ -87,12 +87,10 @@ def decode(obj, chain=None):
                              for d in obj[b'type']]
                 else:
                     descr = obj[b'type']
-                return np.frombuffer(obj[b'data'],
-                            dtype=_unpack_dtype(descr)).reshape(obj[b'shape'])
+                return np.ndarray(obj[b'shape'], _unpack_dtype(descr), obj[b'data'])
             else:
                 descr = obj[b'type']
-                return np.frombuffer(obj[b'data'],
-                            dtype=_unpack_dtype(descr))[0]
+                return np.ndarray((1,), _unpack_dtype(descr), obj[b'data'])[0]
         elif b'complex' in obj:
             return complex(tostr(obj[b'data']))
         else:

--- a/msgpack_numpy.py
+++ b/msgpack_numpy.py
@@ -18,6 +18,7 @@ from msgpack import Packer as _Packer, Unpacker as _Unpacker, \
     unpack as _unpack, unpackb as _unpackb
 import numpy as np
 
+# WIP: correctly serialize object arrays (e.g. arrays of variable-length strings)
 if sys.version_info >= (3, 0):
     if sys.platform == 'darwin':
         ndarray_to_bytes = lambda obj: obj.tobytes()

--- a/tests.py
+++ b/tests.py
@@ -282,5 +282,14 @@ class test_numpy_msgpack(TestCase):
         assert_array_equal(x, x_rec)
         self.assertEqual(x.dtype, x_rec.dtype)
 
+    def test_numpy_object_array(self):
+        dtype = "O"
+
+        x = np.array(["a", "ab", "abc"], dtype=dtype)
+        x_rec = self.encode_decode(x)
+
+        assert_array_equal(x, x_rec)
+        self.assertEqual(x.dtype, x_rec.dtype)
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #46

Avoid using:
```python
np.frombuffer(obj[b'data'], dtype=_unpack_dtype(descr)).reshape(obj[b'shape'])
```

and replace by:
```python
np.ndarray(buffer=obj[b'data'], dtype=_unpack_dtype(descr), shape=obj[b'shape'])
```
